### PR TITLE
Fix default extraction behavior

### DIFF
--- a/.github/workflows/download.yml
+++ b/.github/workflows/download.yml
@@ -12,7 +12,7 @@ jobs:
     steps:
       - name: Wait
         run: sleep 60
-  download-latest:
+  download-default:
     runs-on: ubuntu-latest
     needs: wait
     steps:

--- a/.github/workflows/download.yml
+++ b/.github/workflows/download.yml
@@ -23,6 +23,19 @@ jobs:
         with:
           workflow: upload.yml
           name: artifact
+      - name: Test default behavior
+        run: cat artifact/sha | grep $GITHUB_SHA
+  download-latest:
+    runs-on: ubuntu-latest
+    needs: wait
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Download
+        uses: ./
+        with:
+          workflow: upload.yml
+          name: artifact
           path: artifact
       - name: Test
         run: cat artifact/sha | grep $GITHUB_SHA

--- a/main.js
+++ b/main.js
@@ -140,7 +140,7 @@ async function main() {
                 archive_format: "zip",
             })
 
-            const dir = name ? path : pathname.join(path, artifact.name)
+            const dir = name ? name : pathname.join(path, artifact.name)
 
             fs.mkdirSync(dir, { recursive: true })
 


### PR DESCRIPTION
when not providing extraction path, extract to a directory with the artifact name